### PR TITLE
Adjust hero height to reveal timeline

### DIFF
--- a/css/link.css
+++ b/css/link.css
@@ -1,2 +1,3 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Oswald:wght@200..700&display=swap');
 @import url(style.css);

--- a/css/style.css
+++ b/css/style.css
@@ -1,246 +1,357 @@
-:root{
-    --main-color: red;
+:root {
+    --main-color: #c2574a;
+    --text-color: #2f2f2f;
+    --muted-color: #6a6a6a;
+    --background-color: #f5f3ef;
+    --surface-color: #ffffff;
 }
-body{
-    background: linear-gradient(135deg, #f0f2f5, #e0e4e9);
-    font-family: "Oswald", sans-serif;
-    color: #333;
+
+body {
+    background: var(--background-color);
+    font-family: "Noto Sans TC", "Oswald", sans-serif;
+    color: var(--text-color);
     font-weight: 400;
-    /* font-family: "Oswald", sans-serif;
-    font-optical-sizing: auto;
-    font-weight: 600;
-    font-style: normal; */
+    line-height: 1.7;
+    letter-spacing: 0.01em;
 }
+
+a {
+    color: inherit;
+}
+
 .navbar {
-    background: rgba(255, 255, 255, 0.9);
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    transition: background 0.3s;
+    background: var(--surface-color);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+    transition: background 0.3s ease;
 }
+
 .navbar-light .navbar-nav .nav-link {
-    color: #1D3557;
+    color: var(--muted-color);
     font-weight: 500;
-    transition: color 0.3s;
+    padding: 0.5rem 1rem;
+    transition: color 0.2s ease;
 }
-.navbar-light .navbar-nav .nav-link:hover {
-    color: #E63946;
-    font-weight: bold;
+
+.navbar-light .navbar-nav .nav-link:hover,
+.navbar-light .navbar-nav .nav-link:focus {
+    color: var(--main-color);
 }
-h1, h3 {
-    color: #1D3557;
+
+.logo {
     font-weight: 700;
-    margin-bottom: 1rem;
-    text-shadow: none;
+    letter-spacing: 0.08em;
+    transition: transform 0.2s ease;
 }
-.btn-outline-danger {
-    background: linear-gradient(90deg, #E63946, #1D3557);
-    color: white;
-    border-radius: 25px;
-    transition: all 0.3s ease;
-}
-.btn-outline-danger:hover {
-    background: #1D3557;
-    color: #E63946;
+
+.logo:hover {
     transform: scale(1.05);
 }
-/* .navbar-nav a{
-    transition: 0.5s ease;
-}
-.navbar-nav a:hover{
+
+.logo span {
     color: var(--main-color) !important;
-    font-weight: bold;
-    text-decoration: underline;
-} */
-.logo:hover{
-    transform: scale(1.1);
 }
-.logo span{
-    text-shadow: 0 0 25px var(--main-color);
+
+section {
+    padding: 6rem 0;
 }
-section{
-    min-height: 100vh;
-    padding: 10rem 11% 10rem;
+
+#projects {
+    background: transparent;
 }
-.home-img img{
-    width: 25vw;
-    border-radius: 50%;
-    cursor: pointer;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-    transition: all 0.5s ease;
-    /* box-shadow: 0 0 25px var(--main-color);
-    transition: 0.4s ease-in-out; */
+
+#home {
+    padding: 7rem 0 3rem;
+    min-height: calc(100vh - 5rem);
+    display: flex;
+    align-items: center;
 }
-.home-img img:hover{
-    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.4);
-    transform: scale(1.05);            
-    /* box-shadow: 0 0 25px var(--main-color),
-                0 0 50px var(--main-color),
-                0 0 100px var(--main-color); */
+
+#home > .container {
+    width: 100%;
 }
-.social-icons a{
+
+.home-row {
+    row-gap: 2rem;
+}
+
+.home-content h1 {
+    color: var(--text-color);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.home-content h3 {
+    color: var(--main-color);
+    font-weight: 500;
+    margin-bottom: 1.5rem;
+}
+
+.home-content p {
+    color: var(--muted-color);
+    margin-bottom: 2rem;
+}
+
+.home-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.home-actions .btn {
+    margin: 0;
+    flex: 0 1 auto;
+    text-align: center;
+}
+
+.btn-outline-danger {
+    border-color: var(--main-color);
+    color: var(--main-color);
+    background: transparent;
+    border-radius: 999px;
+    padding: 0.6rem 1.8rem;
+    font-weight: 500;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn-outline-danger:hover,
+.btn-outline-danger:focus {
+    background: var(--main-color);
+    color: #ffffff;
+    border-color: var(--main-color);
+}
+
+.social-icons a {
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    color: #E63946;
-    transition: transform 0.3s ease, color 0.3s ease;
-    /* transition: 0.5s ease-in-out; */
-}
-.social-icons a:hover{
-    color: #1D3557;
-    transform: scale(1.15) translateY(-5px);
-    /* transform: scale(1.3) translateY(-5px); */
-}
-.timeline, .serv {
-    border: 1px solid transparent;
-    background-image: linear-gradient(white, white), radial-gradient(circle at top left, #E63946, #1D3557);
-    background-origin: border-box;
-    background-clip: content-box, border-box;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-.timeline:hover, .serv:hover {
-    box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
-    transform: translateY(-5px);
+    color: var(--main-color);
+    margin-right: 0.5rem;
+    transition: color 0.2s ease, transform 0.2s ease;
 }
 
-/* .timeline{
-    transition: 0.5s ease-in-out;
+.social-icons a:last-child {
+    margin-right: 0;
 }
-.timeline:hover{
-    transform: scale(1.05);
-    box-shadow: 0 0 50px var(--main-color);
-} */
-#education{
-    background-color: rgb(202, 200, 200);
+
+.social-icons a:hover,
+.social-icons a:focus {
+    color: var(--text-color);
+    transform: translateY(-4px);
 }
-/* #projects img:hover{
-    box-shadow: 0px 0px 20px var(--main-color);
-} */
-.serv-row{
-    display: flex;
-    justify-content: center; 
+
+.section-title {
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin-bottom: 2.5rem;
 }
-.serv{
-    background: #f7f9fc;
-    border-radius: 10px;
+
+.section-title span {
+    color: var(--main-color);
+}
+
+.home-img {
+    text-align: center;
+}
+
+.home-img img {
+    width: 100%;
+    max-width: 320px;
+    border-radius: 50%;
     padding: 1.5rem;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    background: var(--surface-color);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
-    /* width: 150px;
-    border: 1px solid darkcyan;
-    margin: 10px 10px;
-    transition: all 0.8s; */
 }
-.serv:hover{
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
-    transform: translateY(-5px);
-    /* border-radius: 50%;
-    background-color: rgb(223, 61, 61); */
+
+.home-img img:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
 }
-#services{
-    background-color: rgb(202, 200, 200);;
-}
-.contact-ul{
-    list-style-type: none;
-}
-h1, h2, h3, h4, h5, p {
-    color: #1D3557;
-    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-}
-h5{
-    margin-top: 20px;
-}
-@media screen and (max-width: 991px) {
-    .arrow{
-        display: none;
+
+@media (max-width: 576px) {
+    .home-actions {
+        flex-direction: column;
+    }
+
+    .home-actions .btn {
+        width: 100%;
     }
 }
-.hero-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 100vh;
-    padding: 0 10%;
-    background: linear-gradient(to right, #1D3557, #E63946);
-    color: white;
+
+.timeline,
+.serv {
+    background: var(--surface-color);
+    border-radius: 16px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.05);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
-.hero-text h1 {
-    font-size: 3.5rem;
-    font-weight: bold;
-    line-height: 1.2;
+
+.timeline:hover,
+.serv:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
 }
-.hero-text p {
-    margin: 20px 0;
-    font-size: 1.5rem;
-    line-height: 1.6;
+
+.projects-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
 }
-.hero-text a {
-    padding: 10px 20px;
-    border-radius: 25px;
-    text-decoration: none;
-    margin-right: 10px;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-.hero-text a:first-child {
-    background: #FFD700;
-    color: #1D3557;
-}
-.hero-text a:first-child:hover {
-    transform: scale(1.1);
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
-}
-.hero-text a:last-child {
-    border: 2px solid #FFD700;
-    color: #FFD700;
-}
-.hero-text a:last-child:hover {
-    background: #FFD700;
-    color: #1D3557;
-}
-.hero-image img {
-    border-radius: 20px;
-    width: 45%;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
-}
-.projects-container h2 {
-    text-align: center;
-    font-size: 2.5rem;
-    margin-bottom: 2rem;
-    color: #1D3557;
+
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
 }
 
 .project-card {
-    background: white;
-    border-radius: 10px;
-    padding: 20px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-    position: relative;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    background: var(--surface-color);
+    border-radius: 16px;
+    padding: 1.75rem;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .project-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-}
-
-.project-card img {
-    width: 100%;
-    border-radius: 10px;
-    margin-bottom: 15px;
+    transform: translateY(-4px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
 }
 
 .project-card h3 {
-    color: #E63946;
+    color: var(--main-color);
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.project-card span {
+    color: var(--muted-color);
+    font-size: 0.95rem;
+}
+
+.project-card p {
+    color: var(--muted-color);
+    margin-bottom: 0;
+}
+
+.project-image {
+    width: 100%;
+    border-radius: 12px;
+}
+
+.project-card > a,
+.project-card > .project-links {
+    margin-top: auto;
 }
 
 .project-card a {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    color: #1D3557;
+    color: var(--main-color);
     text-decoration: none;
-    transition: transform 0.3s ease, color 0.3s ease;
+    transition: color 0.2s ease, transform 0.2s ease;
 }
 
-.project-card a:hover {
-    color: #E63946;
-    transform: scale(1.1) translateY(-5px);
+.project-card a:hover,
+.project-card a:focus {
+    color: var(--text-color);
+    transform: translateY(-3px);
+}
+
+.project-card a i {
+    font-size: 1.05rem;
+}
+
+.project-links {
+    display: flex;
+    gap: 1rem;
+    margin-top: 0.25rem;
+}
+
+.project-links a {
+    display: inline-flex;
+    align-items: center;
+}
+
+.serv-row {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.serv {
+    padding: 1.5rem;
+}
+
+.contact-ul {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+p {
+    color: var(--text-color);
+    text-shadow: none;
+}
+
+h5 {
+    margin-top: 1.25rem;
+}
+
+@media (max-width: 991.98px) {
+    .arrow {
+        display: none;
+    }
+}
+
+@media (max-width: 767.98px) {
+    section {
+        padding: 5rem 0;
+    }
+
+    #home {
+        padding: 6.5rem 0 2.5rem;
+        min-height: auto;
+        display: block;
+    }
+
+    .home-content {
+        text-align: center;
+    }
+
+    .home-content .btn {
+        width: 100%;
+        max-width: 280px;
+        margin: 0 auto 0.75rem;
+        display: block;
+    }
+
+    .social-icons {
+        display: flex;
+        justify-content: center;
+        gap: 0.75rem;
+    }
+
+    .home-img img {
+        margin: 0 auto;
+        padding: 1rem;
+    }
+
+    .home-row {
+        row-gap: 1.5rem;
+    }
+
+    .projects-container {
+        padding: 0 1rem;
+    }
+
+    .projects-grid {
+        gap: 1.25rem;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@
       <!-- 首頁 -->
       <section id="home">
         <div class="container mt-3">
-          <div class="row">
-            <div class="col-12 col-md-6">
+          <div class="row align-items-center home-row">
+            <div class="col-12 col-md-6 order-2 order-md-1 home-content">
               <h1 class="text-secondary">
                 Hello, It's <span class="text-danger">GuoJie</span>
               </h1>
@@ -106,27 +106,29 @@
                   ><i class="bi bi-meta"></i
                 ></a>
               </div>
-              <a
-                href="file/Resume.pdf"
-                target="_blank"
-                class="btn btn-outline-danger rounded-pill mt-3 me-2"
-                >Download Resume</a
-              >
-              <a
-                href="file/project.pdf"
-                target="_blank"
-                class="btn btn-outline-danger rounded-pill mt-3"
-                >Download Portfolio</a
-              >
+              <div class="home-actions">
+                <a
+                  href="file/Resume.pdf"
+                  target="_blank"
+                  class="btn btn-outline-danger rounded-pill"
+                  >Download Resume</a
+                >
+                <a
+                  href="file/project.pdf"
+                  target="_blank"
+                  class="btn btn-outline-danger rounded-pill"
+                  >Download Portfolio</a
+                >
+              </div>
             </div>
             <div
               id="myPhoto"
-              class="wow animate__animated animate__jello home-img col-12 col-md-6 ps-5"
+              class="wow animate__animated animate__jello home-img col-12 col-md-6 order-1 order-md-2"
             >
               <img
                 src="./assets/PortfplioImg.jpg"
-                alt=""
-                class="img-fluid m-5"
+                alt="Portrait of GuoJie"
+                class="img-fluid"
               />
             </div>
           </div>
@@ -222,42 +224,18 @@
       </section>
       <!-- 專案 -->
       <section id="projects">
-        <div
-          class="projects-container"
-          style="padding: 5% 10%; background-color: #f9f9f9"
-        >
-          <h2
-            style="
-              text-align: center;
-              font-size: 2.5rem;
-              margin-bottom: 2rem;
-              color: #1d3557;
-            "
-          >
-            My <span style="color: #e63946">Projects</span>
+        <div class="projects-container">
+          <h2 class="section-title text-center">
+            My <span>Projects</span>
           </h2>
-          <div
-            style="
-              display: grid;
-              grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-              gap: 20px;
-            "
-          >
-            <div
-              class="project-card wow animate__animated animate__fadeInDown"
-              style="
-                background: white;
-                border-radius: 10px;
-                padding: 20px;
-                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-              "
-            >
+          <div class="projects-grid">
+            <div class="project-card wow animate__animated animate__fadeInDown">
               <img
                 alt="Project"
                 src="./assets/NuxtFronted.png"
-                style="width: 100%; border-radius: 10px; margin-bottom: 15px"
+                class="project-image"
               />
-              <h3 style="color: #e63946">書法藝術家線上展覽</h3>
+              <h3>書法藝術家線上展覽</h3>
               <span>[獨立接案]</span>
               <p>
                 以 Nuxt.js 框架開發的響應式個人作品網站，展示書法藝術家的創作。
@@ -266,27 +244,18 @@
               </p>
               <a
                 href="https://www.ruoliwrite.com/"
-                style="text-decoration: none; color: #1d3557"
                 target="_blank"
                 ><i class="fa-solid fa-arrow-up-right-from-square"></i
               ></a>
             </div>
 
-            <div
-              class="project-card wow animate__animated animate__bounceInLeft"
-              style="
-                background: white;
-                border-radius: 10px;
-                padding: 20px;
-                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-              "
-            >
+            <div class="project-card wow animate__animated animate__bounceInLeft">
               <img
                 alt="Project"
                 src="./assets/Write.png"
-                style="width: 100%; border-radius: 10px; margin-bottom: 15px"
+                class="project-image"
               />
-              <h3 style="color: #e63946">書法展覽後台管理系統</h3>
+              <h3>書法展覽後台管理系統</h3>
               <span>[獨立接案]</span>
               <p>
                 本專案以 ASP.NET Core MVC
@@ -295,27 +264,18 @@
               </p>
               <a
                 href="https://www.ruolibackend.com/"
-                style="text-decoration: none; color: #1d3557"
                 target="_blank"
                 ><i class="fa-solid fa-arrow-up-right-from-square"></i
               ></a>
             </div>
 
-            <div
-              class="project-card wow animate__animated animate__bounceInDown"
-              style="
-                background: white;
-                border-radius: 10px;
-                padding: 20px;
-                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-              "
-            >
+            <div class="project-card wow animate__animated animate__bounceInDown">
               <img
                 alt="Project"
                 src="./assets/mygoparking.png"
-                style="width: 100%; border-radius: 10px; margin-bottom: 15px"
+                class="project-image"
               />
-              <h3 style="color: #e63946">MyGoParking</h3>
+              <h3>MyGoParking</h3>
               <p>
                 停車場搜尋Web服務, 三層式架構, 前端以Vue為框架, 後端.Net Core
                 Web Api, 資料庫SQL Server. 提供預約車位服務,
@@ -323,98 +283,70 @@
               </p>
               <a
                 href="#"
-                style="text-decoration: none; color: #1d3557"
                 target="_blank"
                 ><i class="fa-solid fa-arrow-up-right-from-square"></i
               ></a>
             </div>
 
-            <div
-              class="project-card wow animate__animated animate__backInDown"
-              style="
-                background: white;
-                border-radius: 10px;
-                padding: 20px;
-                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-              "
-            >
+            <div class="project-card wow animate__animated animate__backInDown">
               <img
                 alt="Project"
                 src="./assets/parklot.png"
-                style="width: 100%; border-radius: 10px; margin-bottom: 15px"
+                class="project-image"
               />
-              <h3 style="color: #e63946">停車場管理系統</h3>
+              <h3>停車場管理系統</h3>
               <p>
                 此專案是針對停車場後台管理的系統,
                 提供了即時查詢、資料編輯、刪除和新增等功能.
               </p>
               <a
                 href="https://github.com/GUOJIE526/MyGoParkingManagement"
-                style="text-decoration: none; color: #1d3557"
                 target="_blank"
                 ><i class="bi bi-github"></i
               ></a>
             </div>
-            <div
-              class="project-card wow animate__animated animate__fadeInRightBig"
-              style="
-                background: white;
-                border-radius: 10px;
-                padding: 20px;
-                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-              "
-            >
+            <div class="project-card wow animate__animated animate__fadeInRightBig">
               <img
                 alt="Project"
                 src="./assets/PharmacyShop.png"
-                style="width: 100%; border-radius: 10px; margin-bottom: 15px"
+                class="project-image"
               />
-              <h3 style="color: #e63946">線上藥局</h3>
+              <h3>線上藥局</h3>
               <p>
                 運用C# ADO.Net WinForm及MS SQL製作的線上藥局商城,
                 具備了會員管理、商品管理、員工管理、訂單管理和系統管理.
               </p>
               <a
                 href="https://github.com/GUOJIE526/PharmacyShop2.0"
-                style="text-decoration: none; color: #1d3557"
                 target="_blank"
                 ><i class="bi bi-github"></i
               ></a>
             </div>
 
-            <div
-              class="project-card wow animate__animated animate__zoomInUp"
-              style="
-                background: white;
-                border-radius: 10px;
-                padding: 20px;
-                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-              "
-            >
+            <div class="project-card wow animate__animated animate__zoomInUp">
               <img
                 alt="Project"
                 src="./assets/cat-search.jpg"
-                style="width: 100%; border-radius: 10px; margin-bottom: 15px"
+                class="project-image"
               />
-              <h3 style="color: #e63946">搜索喵喵</h3>
+              <h3>搜索喵喵</h3>
               <p>
                 Cat Search 是一個用於搜索貓咪品種並顯示其詳細信息的Web
                 APP。用戶可以選擇不同的貓咪品種並查看其詳細資料
                 ，包括圖片、品種名稱、原產地、壽命、體重、性格等。
               </p>
-              <a
-                href="https://github.com/GUOJIE526/Cat-Search"
-                style="text-decoration: none; color: #1d3557"
-                target="_blank"
-                class="me-2"
-                ><i class="bi bi-github"></i
-              ></a>
-              <a
-                href="https://guojie526.github.io/Cat-Search/"
-                style="text-decoration: none; color: #1d3557"
-                target="_blank"
-                ><i class="fa-solid fa-arrow-up-right-from-square"></i
-              ></a>
+              <div class="project-links">
+                <a
+                  href="https://github.com/GUOJIE526/Cat-Search"
+                  target="_blank"
+                  ><i class="bi bi-github"></i
+                ></a>
+                <a
+                  href="https://guojie526.github.io/Cat-Search/"
+                  target="_blank"
+                  ><i class="fa-solid fa-arrow-up-right-from-square"></i
+                ></a>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- shorten the hero section padding and flex layout so the Education & Experience heading peeks into the viewport on load
- ensure the home container still centers its content while respecting the new height treatment
- relax the mobile breakpoint styling so small screens use natural height and stacked layout

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d01092ec18832bb33c6d0863c755b5